### PR TITLE
Add Minecraft Java Edition

### DIFF
--- a/assets/config.yml
+++ b/assets/config.yml
@@ -1962,6 +1962,12 @@ services:
 
       - name: "Minecraft"
         logo: "assets/tools/Minecraft.png"
+        subtitle: "Java Edition"
+        url: "https://www.minecraft.net/download"
+        target: "_blank" # optional html a tag target attribute
+
+      - name: "Minecraft"
+        logo: "assets/tools/Minecraft.png"
         tag: "Purchases"
         subtitle: "Bedrock"
         url: "https://apps.microsoft.com/detail/9NBLGGH2JHXJ"


### PR DESCRIPTION
Minecraft: Java Edition supports running natively on WoA via its first-party "legacy launcher" since 1.19.x (see https://github.com/adiantek/mc-spx/pull/21 for reference), with the caveat of the launcher itself still using x86 emulation.