### PR TITLE
Add ARM32 tag to fluentcast

### DIFF
--- a/assets/config.yml
+++ b/assets/config.yml
@@ -309,6 +309,7 @@ services:
 
       - name: "FluentCast"
         logo: "assets/tools/fluentcast.png"
+        tag: "ARM32"
         subtitle: "free and Ad-free podcast app"
         url: "https://apps.microsoft.com/detail/9pm46jrsdqqr"
         target: "_blank" # optional html a tag target attribute


### PR DESCRIPTION
Adding a tag to indicate [FluentCast](https://apps.microsoft.com/detail/9pm46jrsdqqr) is ARM32 only.

MS will [deprecate 32-bit ARM UWP applications](https://learn.microsoft.com/en-us/windows/arm/arm32-to-arm64) in a future release of Windows 11. Installing the app on the latest Beta channel of Windows 11 will give you the emulated x64 version.